### PR TITLE
Decode continuation opcode into Continuation frame

### DIFF
--- a/src/main/scala/org/http4s/websocket/WebsocketBits.scala
+++ b/src/main/scala/org/http4s/websocket/WebsocketBits.scala
@@ -28,6 +28,8 @@ object WebsocketBits {
 
     case WebsocketBits.BINARY => Binary(data, last)
 
+    case WebsocketBits.CONTINUATION => Continuation(data, last)
+
     case WebsocketBits.PING =>
       if (!last) throw new ProtocolException("Control frame cannot be fragmented: Ping")
       else Ping(data)

--- a/src/test/scala/org/http4s/websocket/WebsocketSpec.scala
+++ b/src/test/scala/org/http4s/websocket/WebsocketSpec.scala
@@ -65,6 +65,14 @@ class WebsocketSpec extends Specification {
       new String(msg.data, UTF_8) should_== "Hello"
     }
 
+    "encode a continuation message" in {
+      val frame = Continuation("Hello".getBytes(UTF_8), true)
+      val msg = decode(encode(frame, true), false)
+      msg should_== frame
+      msg.last should_== true
+      new String(msg.data, UTF_8) should_== "Hello"
+    }
+
     "encode and decode a message with 125 < len <= 0xffff" in {
       val bytes = (0 until 0xfff).map(_.toByte).toArray
       val frame = Binary(bytes, false)


### PR DESCRIPTION
Oh. So the change was just that small.

I've tested by publishing locally, and also publishing locally a version of http4s that uses this branch.  My application no longer produces the match error mentioned in the ticket.

However: I was expecting my application to have to handle `Continuation` messages during my own `WebSocketFrame => Task[Unit]`  function.  I don't see them (suits me!), and yet my application works. So I'll sit on this for a while and see if I can figure out why it works.

Re: #1
