### PR TITLE
Get working on JDK >= 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: scala
-scala:
-- 2.10.7
-- 2.11.12
-- 2.12.6
-- 2.13.0-M4
 
-jdk: oraclejdk8
+matrix:
+  include:
+  - jdk: oraclejdk8
+    scala: 2.13.0-M4
+  - jdk: oraclejdk8
+    scala: 2.12.6
+  - jdk: oraclejdk8
+    scala: 2.11.12
+  - jdk: oraclejdk8
+    scala: 2.10.7
+  - jdk: oraclejdk10
+    scala: 2.12.6
 
 sudo: false
 cache:

--- a/shared/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
+++ b/shared/src/main/scala/org/http4s/websocket/FrameTranscoder.scala
@@ -161,11 +161,11 @@ class FrameTranscoder(val isClient: Boolean) {
         null
       }
 
-      val oldLim = in.limit
+      val oldLim = in.limit()
       val bodylen = FrameTranscoder.bodyLength(in)
 
       in.position(bodyOffset)
-      in.limit(in.position + bodylen)
+      in.limit(in.position() + bodylen)
 
       val slice = in.slice
       in.position(in.limit)

--- a/shared/src/main/scala/org/http4s/websocket/WebsocketHandshake.scala
+++ b/shared/src/main/scala/org/http4s/websocket/WebsocketHandshake.scala
@@ -2,8 +2,7 @@ package org.http4s.websocket
 
 import java.nio.charset.StandardCharsets._
 import java.security.MessageDigest
-import javax.xml.bind.DatatypeConverter._
-
+import java.util.Base64
 import scala.util.Random
 
 
@@ -19,7 +18,7 @@ object WebsocketHandshake {
     val key = {
       val bytes = new Array[Byte](16)
       Random.nextBytes(bytes)
-      printBase64Binary(bytes)
+      Base64.getEncoder.encodeToString(bytes)
     }
 
     /** Initial headers to send to the server */
@@ -68,7 +67,7 @@ object WebsocketHandshake {
     headers.exists{ case (k, v) => k.equalsIgnoreCase("Upgrade") && v.equalsIgnoreCase("websocket") }
   }
 
-  private def decodeLen(key: String): Int = parseBase64Binary(key).length
+  private def decodeLen(key: String): Int = Base64.getDecoder.decode(key).length
 
   private def genAcceptKey(str: String): String = {
     val crypt = MessageDigest.getInstance("SHA-1")
@@ -76,7 +75,7 @@ object WebsocketHandshake {
     crypt.update(str.getBytes(US_ASCII))
     crypt.update(magicString)
     val bytes = crypt.digest()
-    printBase64Binary(bytes)
+    Base64.getEncoder.encodeToString(bytes)
   }
 
   private[websocket] def valueContains(key: String, value: String): Boolean = {


### PR DESCRIPTION
* Use parentheses to deal with new overloads on `ByteBuffer`
* Replace `DatatypeConverter` (modularized in jdk9) with `Base64` (introduced in jdk8)

Fixes #12.